### PR TITLE
lays the groundwork for lightning_panels to support view modes for all revisions.

### DIFF
--- a/lightning_panels/lightning_panels.module
+++ b/lightning_panels/lightning_panels.module
@@ -29,11 +29,21 @@ function lightning_panels_pre_features_rebuild($component) {
  */
 function lightning_panels_node_update($node) {
   if (!empty($node->old_vid)) {
-    $old_did = db_query("SELECT did FROM {panelizer_entity} WHERE entity_id = :nid AND revision_id = :oldvid ORDER BY revision_id DESC",
-        array(":nid" => $node->nid, ":oldvid" => $node->old_vid))
-      ->fetchField();
-    if (!empty($old_did) && !empty($node->panelizer['page_manager']) && empty($node->panelizer['page_manager']->did)) {
-      $node->panelizer['page_manager']->did = $old_did;
+    $results = db_select('panelizer_entity', 'pe')
+      ->fields('pe', array('did', 'view_mode'))
+      ->condition('pe.entity_type', 'node')
+      ->condition('pe.entity_id', $node->nid)
+      ->condition('pe.revision_id', $node->old_vid)
+      ->isNull('pe.name')
+      ->execute();
+    foreach ($results as $result) {
+      if ($result->did) {
+        $node->panelizer[$result->view_mode]->did = $result->did;
+        $node->panelizer[$result->view_mode]->display_is_modified = TRUE;
+      }
+      else {
+        // No custom display found, fallback to defaults.
+      }
     }
   }
 }


### PR DESCRIPTION
Currently lightning_panels is only looking at the page_manager view_mode and supporting all of them should be fairly easy. I've also added the appropriate settings to tell panelizer that this revision should be cloned if it's reusing an existing display id (for example when we're doing node reverts, and this appears to be the expected behavior after having ready panelizer code for quite some time).
