### PR TITLE
adding a patch that keeps IPE cache_keys in sync with the changing cache...

### DIFF
--- a/lightning_features.make
+++ b/lightning_features.make
@@ -327,6 +327,9 @@ projects[panels][subdir] = "contrib"
 ; Fix IPE JS alert (Panelizer is Incompatible with Moderation)
 ; http://drupal.org/node/1402860#comment-9729091
 projects[panels][patch][1402860] = "http://drupal.org/files/issues/panelizer_is-1402860-82-fix-ipe-end-js-alert.patch"
+; IPE Insufficient for working with Panelizer Revisioning
+; https://www.drupal.org/node/2462331#comment-9778921
+projects[panels][patch][2462331] = "http://www.drupal.org/files/issues/2462331-4.patch"
 
 projects[panopoly_magic][version] = "1.x-dev"
 projects[panopoly_magic][type] = "module"


### PR DESCRIPTION
... key generated by panelizer during entity revisions
