### PR TITLE
Update Entity Embed to fix compatibility issues with the UUID module.

### DIFF
--- a/lightning_features.make
+++ b/lightning_features.make
@@ -124,7 +124,7 @@ projects[entity_embed][version] = "1.x-dev"
 projects[entity_embed][type] = "module"
 projects[entity_embed][subdir] = "contrib"
 projects[entity_embed][download][type] = "git"
-projects[entity_embed][download][revision] = "b7f1e17"
+projects[entity_embed][download][revision] = "6a5bc7d"
 projects[entity_embed][download][branch] = "7.x-1.x"
 
 projects[entityreference][version] = "1.x-dev"


### PR DESCRIPTION
The Entity Embed module for Drupal 7 has basic support for UUIDs but lacked test coverage when used in combination with the UUID module (UUIDs handling is included with Drupal 8 core).

I uncovered and fixed a few compatibility issues between Entity Embed and UUID, plus expanded the UUID test coverage to match that of the Drupal 8 version. This solves the embed issues with Demo Framework which aren't found in Lightning, as Demo employs UUIDs while Lightning doesn't.
