### PR TITLE
Added patches for fixing Workbench block bug

### DIFF
--- a/lightning_features.make
+++ b/lightning_features.make
@@ -542,7 +542,7 @@ projects[workbench_moderation][subdir] = "contrib"
 projects[workbench_moderation][patch][2462453] = "http://drupal.org/files/issues/workbench_moderation-iib-var-2462453-1.patch"
 ; Provide an AJAX callback to reload the Workbench block, for inline editing support
 ; https://www.drupal.org/node/2485713
-projects[workbench_moderation][patch][2485713] = "http://www.drupal.org/files/issues/workbench-moderation-ajax-block-2485713-3_0.patch"
+projects[workbench_moderation][patch][2485713] = "http://www.drupal.org/files/issues/workbench-moderation-ajax-block-2485713-6.patch"
 
 projects[workbench_moderation_buttons][version] = "1.x-dev"
 projects[workbench_moderation_buttons][type] = "module"


### PR DESCRIPTION
This PR adds three patches to fix a bug where after inline-editing with Panels IPE or Quickedit, you can no longer change the Workbench state of a node via the Workbench block. While I'm not sure if the maintainers of these modules will ever accept my patches (they're extremely specific), this fixes our bugs with demos and Lightning-specific features (the off-canvas moderate tab specifically). 

Please test and review the patches here or on Drupal.org.
