### PR TITLE
Workbench moderation warnings on installation and features revert

### DIFF
--- a/lightning_features.make
+++ b/lightning_features.make
@@ -528,6 +528,9 @@ projects[workbench_moderation][patch][2462453] = "http://drupal.org/files/issues
 ; Provide an AJAX callback to reload the Workbench block, for inline editing support
 ; https://www.drupal.org/node/2485713
 projects[workbench_moderation][patch][2485713] = "http://www.drupal.org/files/issues/workbench-moderation-ajax-block-2485713-6.patch"
+; Fix warnings on installation and features revert.
+; https://www.drupal.org/node/2360973
+projects[workbench_moderation][patch][2360973] = "https://www.drupal.org/files/issues/workbench_moderation-install-warnings-2360973-3.patch"
 
 projects[workbench_moderation_buttons][version] = "1.0-alpha3"
 projects[workbench_moderation_buttons][type] = "module"


### PR DESCRIPTION
Adds a simple patch that we've use for a while now to fix these warnings.
