### PR TITLE
Added dependency for editor module

### DIFF
--- a/lightning_wysiwyg/lightning_wysiwyg.info
+++ b/lightning_wysiwyg/lightning_wysiwyg.info
@@ -5,6 +5,7 @@ package = Lightning
 version = 7.x-1.0
 project = lightning_wysiwyg
 dependencies[] = ctools
+dependencies[] = editor
 dependencies[] = editor_ckeditor
 dependencies[] = features
 datestamp = 1408404197


### PR DESCRIPTION
Using drush to enable this feature from a clean install gave me the error:

"Module lightning_wysiwyg cannot be enabled because it depends on the following modules which could not be found: editor_ckeditor"

Adding editor as a dependency fixes this.
